### PR TITLE
Fixed allowTouchOutsideToDismiss being set to false not working.

### DIFF
--- a/Example/ZAlertView/ViewController.swift
+++ b/Example/ZAlertView/ViewController.swift
@@ -28,6 +28,7 @@ class ViewController: UIViewController {
                 alertView.dismiss()
             }
         )
+        dialog.allowTouchOutsideToDismiss = false
         
         dialog.show()
     }
@@ -46,6 +47,7 @@ class ViewController: UIViewController {
             }
         )
         dialog.show()
+        dialog.allowTouchOutsideToDismiss = true
     }
     
     @IBAction func inputDialogButtonDidTouch(sender: AnyObject) {

--- a/Pod/Classes/ZAlertView.swift
+++ b/Pod/Classes/ZAlertView.swift
@@ -92,8 +92,19 @@ public class ZAlertView: UIViewController {
         }
     }
     
+    public var allowTouchOutsideToDismiss: Bool = true {
+        didSet {
+            if allowTouchOutsideToDismiss == false {
+                self.tapOutsideTouchGestureRecognizer.removeTarget(self, action: "dismiss")
+            }
+            else {
+                self.tapOutsideTouchGestureRecognizer.addTarget(self, action: "dismiss")
+            }
+        }
+    }
+    private var tapOutsideTouchGestureRecognizer: UITapGestureRecognizer = UITapGestureRecognizer()
+    
     public var isOkButtonLeft: Bool = false
-    public var allowTouchOutsideToDismiss: Bool = true
     public var width: CGFloat = ZAlertView.AlertWidth
     public var height: CGFloat = ZAlertView.AlertHeight
 
@@ -219,11 +230,10 @@ public class ZAlertView: UIViewController {
             self.backgroundView.alpha = ZAlertView.backgroundAlpha
         }
         // Gesture for background
-        if allowTouchOutsideToDismiss {
-            let touchGesture = UITapGestureRecognizer()
-            touchGesture.addTarget(self, action: Selector("dismiss"))
-            backgroundView.addGestureRecognizer(touchGesture)
+        if allowTouchOutsideToDismiss == true {
+            self.tapOutsideTouchGestureRecognizer.addTarget(self, action: "dismiss")
         }
+        backgroundView.addGestureRecognizer(self.tapOutsideTouchGestureRecognizer)
         self.view.addSubview(backgroundView)
         
         // Setup alert view


### PR DESCRIPTION
This PR fixes a bug where setting allowTouchOutsideToDismiss to false would not work - the alert would always dismiss on a touch outside of it no matter what this boolean was set to. 
Now it is possible to set allowTouchOutsideToDismiss to false and it
will work, disallowing the user from touching outside of the alert to
dismiss.
