### PR TITLE
Buttons can have individual colors

### DIFF
--- a/Pod/Classes/ZAlertView.swift
+++ b/Pod/Classes/ZAlertView.swift
@@ -78,10 +78,10 @@ public class ZAlertView: UIViewController {
     public static var negativeColor: UIColor?            = UIColor(red:0.91, green:0.3, blue:0.24, alpha:1.0)
     public static var neutralColor: UIColor?             = UIColor(red:0.93, green:0.94, blue:0.95, alpha:1.0)
     public static var titleColor: UIColor?               = UIColor(red:0.5, green:0.55, blue:0.55, alpha:1.0)
-    public static var buttonTitleColor: UIColor?         = UIColor.whiteColor()
     public static var messageColor: UIColor?             = UIColor(red:0.5, green:0.55, blue:0.55, alpha:1.0)
-    public static var cancelTextColor: UIColor?          = UIColor(red:0.5, green:0.55, blue:0.55, alpha:1.0)
-    public static var normalTextColor: UIColor?          = UIColor.whiteColor()
+    public static var buttonTitleColor: UIColor?         = UIColor.whiteColor()
+    public static var buttonCancelColor: UIColor?        = UIColor(red:0.5, green:0.55, blue:0.55, alpha:1.0)
+    public static var buttonCloseColor: UIColor?         = UIColor.whiteColor()
     public static var textFieldTextColor: UIColor?       = UIColor(red:0.5, green:0.55, blue:0.55, alpha:1.0)
     public static var textFieldBorderColor: UIColor?     = UIColor(red:0.5, green:0.55, blue:0.55, alpha:1.0)
     public static var textFieldBackgroundColor: UIColor? = UIColor.whiteColor()
@@ -294,7 +294,7 @@ public class ZAlertView: UIViewController {
             self.btnCancel.setTitle("Cancel", forState: UIControlState.Normal)
         }
         self.btnCancel.titleLabel?.font = ZAlertView.buttonFont ?? UIFont.boldSystemFontOfSize(14)
-        self.btnCancel.titleColor = ZAlertView.buttonTitleColor
+        self.btnCancel.titleColor = ZAlertView.buttonCancelColor
         self.alertView.addSubview(btnCancel)
         
         // Setup Close button
@@ -305,7 +305,7 @@ public class ZAlertView: UIViewController {
             self.btnClose.setTitle("Close", forState: UIControlState.Normal)
         }
         self.btnClose.titleLabel?.font = ZAlertView.buttonFont ?? UIFont.boldSystemFontOfSize(14)
-        self.btnClose.titleColor = ZAlertView.buttonTitleColor
+        self.btnClose.titleColor = ZAlertView.buttonCloseColor
         self.alertView.addSubview(btnClose)
     }
     


### PR DESCRIPTION
It appears that although there are variables in place to allow buttons to have different title colors, none of them are being utilized. This pull requests adds three different types of button title colors similar to how the existing app has different colors for positive, negative and neutral.
